### PR TITLE
Deal with IP address more gracefully

### DIFF
--- a/source/claire.js
+++ b/source/claire.js
@@ -44,7 +44,9 @@ define([ 'request' ], function( Request ) {
 
 		if ( details.tabId in window.requests ) {
 			var request = window.requests[details.tabId];
-			request.querySPDYStatusAndSetIcon();
+			if ( ! request.details.fromCache ) {
+				request.querySPDYStatusAndSetIcon();
+			}
 		}
 	});
 

--- a/source/request.js
+++ b/source/request.js
@@ -194,7 +194,7 @@ define([ 'airports' ], function( airports ) {
 	};
 
 	Request.prototype.getServerIP = function() {
-		return this.details.ip;
+		return (this.details.ip) ? this.details.ip : '';
 	};
 
 	Request.prototype.isv6IP = function() {


### PR DESCRIPTION
 - No longer causes type error on cached pages like the new tab window
 - Preserves exiting behavior of not showing the icon when retrieved
 from local cache

( Fixes #14 )