### PR TITLE
Resolve issue #26

### DIFF
--- a/source/page_action_popup.html
+++ b/source/page_action_popup.html
@@ -50,6 +50,14 @@
           <p><span id="locationName"></span> (<span id="locationCode"></span>)</p>
         </section>
       </section>
+      <section id="trace" class="card">
+        <header class="card-header">
+          <h2 class="card-title">Trace</h2>
+        </header>
+        <section class="card-body">
+          <p><a id="traceURL" target="_blank">Trace Details link</a></p>
+        </section>
+      </section>
       <section id="railgun" class="card">
         <header class="card-header">
           <h2 class="card-title">Railgun</h2>

--- a/source/page_action_popup.js
+++ b/source/page_action_popup.js
@@ -38,9 +38,11 @@
       $('#rayID').val(request.getRayID());
       $('#locationCode').text(request.getCloudFlareLocationCode());
       $('#locationName').text(request.getCloudFlareLocationName());
+      $('#traceURL').attr('href', request.getCloudFlareTrace());
     } else {
       $('#ray').attr('hidden', true);
       $('#loc').attr('hidden', true);
+      $('#trace').attr('hidden', true);
     }
 
     // show Railgun related info
@@ -56,4 +58,3 @@
     }
   });
 })();
-

--- a/source/request.js
+++ b/source/request.js
@@ -181,6 +181,14 @@ define(['airports'], function (airports) {
     return this.getCloudFlareLocationCode();
   };
 
+  Request.prototype.getCloudFlareTrace = function () {
+    // Use the URL object that is returned via tabID to match a domain
+    // e.g. http://www.example.com/subfolder/item would result in http://www.example.com
+    var traceDomain = this.details.url.match(/^[\w-]+:\/*\[?([\w\.:-]+)\]?(?::\d+)?/)[0];
+    var traceURL = traceDomain + '/cdn-cgi/trace';
+    return traceURL;
+  };
+
   Request.prototype.getTabID = function () {
     return this.details.tabId;
   };
@@ -281,4 +289,3 @@ define(['airports'], function (airports) {
 
   return Request;
 });
-

--- a/source/request.js
+++ b/source/request.js
@@ -182,11 +182,9 @@ define(['airports'], function (airports) {
   };
 
   Request.prototype.getCloudFlareTrace = function () {
-    // Use the URL object that is returned via tabID to match a domain
-    // e.g. http://www.example.com/subfolder/item would result in http://www.example.com
-    var traceDomain = this.details.url.match(/^[\w-]+:\/*\[?([\w\.:-]+)\]?(?::\d+)?/)[0];
-    var traceURL = traceDomain + '/cdn-cgi/trace';
-    return traceURL;
+    var traceURL = new URL(this.details.url);
+    traceURL.pathname = '/cdn-cgi/trace';
+    return traceURL.toString();
   };
 
   Request.prototype.getTabID = function () {


### PR DESCRIPTION
I have reworked the request.js code to gain the domain through a match on the this.details object.


-----

This PR updates Claire to include an additional card that contains a link to the /cdn-cgi/trace page for the current domain, this is only shown when the site is going through CloudFlare.

Confirmed working on https://www.trozzy.net/ and http://test.subdomain.trozzy.net/ to confirm the match regex.

@terinjokes is this more towards the method that is preferred?