### PR TITLE
Firefox compatibility (but HTTP/2 indicator does not work yet)

### DIFF
--- a/source/contentscript.js
+++ b/source/contentscript.js
@@ -1,6 +1,12 @@
 // when asked tell the extension about the SPDY/HTTP2 status of current page
 
 function determineConnectionInfo() {
+  if (chrome.loadTimes === undefined) {
+    return {
+      spdy: false,
+      type: ''
+    };
+  }
   var loadTimes = chrome.loadTimes();
   return {
     spdy: loadTimes.wasFetchedViaSpdy,

--- a/source/request.js
+++ b/source/request.js
@@ -29,6 +29,16 @@ define(['airports'], function (airports) {
     if ('CF-RAILGUN' in this.headers) {
       this.processRailgunHeader();
     }
+
+    if ('X-FIREFOX-SPDY' in this.headers) {
+      this.processFirefoxSpdyHeader();
+    }
+  };
+
+  Request.prototype.processFirefoxSpdyHeader = function () {
+    this.hasConnectionInfo = true;
+    this.SPDY = true;
+    this.connectionType = (this.headers['X-FIREFOX-SPDY'] === 'h2') ? 'h2' : 'spdy';
   };
 
   Request.prototype.processRailgunHeader = function () {


### PR DESCRIPTION
Looks like https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/Tabs/onReplaced is not implemented despite documentation saying otherwise.
