### PR TITLE
Use `options_ui` to specify the Options Page

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -28,6 +28,9 @@
     "js" : ["contentscript.js"],
     "run_at": "document_start"
   }],
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "content_security_policy": "object-src 'self'; script-src 'self' 'unsafe-eval';"
 }


### PR DESCRIPTION
The [`options_page`](https://developer.chrome.com/extensions/options) key is deprecated and [hasn’t been implemented in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1212684) and will be eventually removed from Chrome as well, and as such, shouldn’t be used anymore.

Needed for #12