### PR TITLE
fix: change when contentscript runs

### DIFF
--- a/source/claire.js
+++ b/source/claire.js
@@ -35,24 +35,11 @@ define(['./request'], function (Request) {
     }
   });
 
-  chrome.webNavigation.onDOMContentLoaded.addListener(function (details) {
-    if (details.frameId > 0) {
-      // we don't care about sub-frame window.requests
-      return;
-    }
-
-    if (details.tabId in window.requests) {
-      var request = window.requests[details.tabId];
-      if (!request.details.fromCache) {
-        request.queryConnectionInfoAndSetIcon();
-      }
-    }
-  });
-
   chrome.runtime.onMessage.addListener(function (csRequest, sender, sendResponse) {
     var request = window.requests[sender.tab.id];
     if (request) {
       request.setConnectionInfo(csRequest);
+      request.setPageActionIconAndPopup();
     }
     sendResponse({});
   });

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -28,7 +28,7 @@
   "content_scripts": [{
     "matches": ["<all_urls>"],
     "js" : ["contentscript.js"],
-    "run_at": "document_start"
+    "run_at": "document_end"
   }],
   "options_ui": {
     "page": "options.html",

--- a/source/request.js
+++ b/source/request.js
@@ -105,36 +105,6 @@ Request.prototype.processRailgunHeader = function () {
   this.railgunMetaData.messages = messages;
 };
 
-Request.prototype.queryConnectionInfoAndSetIcon = function () {
-  var tabID = this.details.tabId;
-  if (this.hasConnectionInfo) {
-    this.setPageActionIconAndPopup();
-  } else {
-    var csMessageData = {
-      action: 'check_connection_info'
-    };
-    var csMessageCallback = function (csMsgResponse) {
-      // stop and return if we don't get a response, happens with background tabs,
-      // or if the next hop information is unavailable.
-      if (typeof csMsgResponse === 'undefined') {
-        return;
-      }
-
-      var request = window.requests[tabID];
-      request.setConnectionInfo(csMsgResponse);
-      request.setPageActionIconAndPopup();
-    };
-
-    try {
-      chrome.tabs.sendMessage(this.details.tabId, csMessageData, csMessageCallback);
-    } catch (err) {
-      console.log('caught exception when sending message to content script');
-      console.log(chrome.extension.lastError());
-      console.log(err);
-    }
-  }
-};
-
   // check if the server header matches 'cloudflare-nginx'
 Request.prototype.servedByCloudFlare = function () {
   return ('SERVER' in this.headers) && (/^cloudflare/i.test(this.headers.SERVER));


### PR DESCRIPTION
The nextHopProto information is no longer available at the beginning of
the document. This change waits until the DOM has loaded before sending
the connection type. As a result, the eager fetching of connection info
has been removed.