### PR TITLE
Claire Deprecation Announcement

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ![Deprecated](https://img.shields.io/badge/STATUS-DEPRECATED-E81403)
 
-Claire has been deprecated by **Optics** (https://github.com/cloudflare/optics), which was launched with Manifest V3 and Firefox support.
+Claire has been deprecated by **Optics**, which was launched with Manifest V3 and Firefox support.
 
 ## Downloads for Optics
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ![Deprecated](https://img.shields.io/badge/STATUS-DEPRECATED-E81403)
 
-Claire has been deprecated by **Optics** (https://github.com/cloudflare/optics), which was launched with Manifest V3 and support for Firefox.
+Claire has been deprecated by **Optics** (https://github.com/cloudflare/optics), which was launched with Manifest V3 and Firefox support.
 
 ## Downloads for Optics
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,23 +1,31 @@
+# **Claire (Deprecated by Optics)**
+
+![Deprecated](https://img.shields.io/badge/STATUS-DEPRECATED-E81403)
+
+Claire has been deprecated by **Optics**, which was launched with Manifest V3 and support for Firefox.
+
+## Downloads for Optics
+
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/mdjgbjnbdnhneejmmaabmccfehigbjbe.svg)](https://chrome.google.com/webstore/detail/optics/mdjgbjnbdnhneejmmaabmccfehigbjbe)
+[![Firefox Add-ons](https://img.shields.io/amo/v/cloudflare-optics.svg)](https://addons.mozilla.org/firefox/addon/cloudflare-optics/)
+
+##
+##
+
+<details>
+
+<summary>Previous Claire Repository Information</summary>
+
 # Claire
-[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/fgbpcgddpmjmamlibbaobboigaijnmkl.svg?style=flat-square)](https://chrome.google.com/webstore/detail/claire/fgbpcgddpmjmamlibbaobboigaijnmkl)
-[![Firefox Add-ons](https://img.shields.io/amo/v/cloudflare-claire.svg?style=flat-square)](https://addons.mozilla.org/en-US/firefox/addon/cloudflare-claire/)
+
+**-- Claire Downloads Removed --**
 
 Claire is a Google Chrome extension that turns orange if the current page is on the [Cloudflare](https://www.cloudflare.com) network.
 Clicking on the icon will show additional information about the page.
 
 ## Installation
 
-### From Chrome Web Store
-
-Install the pre-packaged version of Claire from the Chrome Web Store
-
-[![Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/claire/fgbpcgddpmjmamlibbaobboigaijnmkl)
-
-### From Firefox Add-ons
-
-Install the pre-packaged version of Claire from the Firefox Add-ons site
-
-[![Firefox Add-ons](https://addons.cdn.mozilla.net/static/img/addons-buttons/AMO-button_1.png)](https://addons.mozilla.org/en-US/firefox/addon/cloudflare-claire/)
+**-- Claire Downloads Removed --**
 
 ### From source
 
@@ -29,8 +37,11 @@ To use the extension from source:
 * If Developer mode is not checked, check it and this will expose a few additional buttons
 * Click on the Load unpacked extension button and browse to the "dist" folder in the Claire repo folder
 
-## Sharing & Contributing
+##
+##
 
-You can use this short URL to share Claire https://is.gd/claire
+# Claire's Previous Markdown
+An unedited version of the previous README can be found here:
+https://github.com/cloudflare/claire/blob/4620115c4c7e216eeafcb2acce6e49ad6e58086a/README.markdown
 
-Fork away and send pull requests
+</details>

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ![Deprecated](https://img.shields.io/badge/STATUS-DEPRECATED-E81403)
 
-Claire has been deprecated by **Optics**, which was launched with Manifest V3 and support for Firefox.
+Claire has been deprecated by **Optics** (https://github.com/cloudflare/optics), which was launched with Manifest V3 and support for Firefox.
 
 ## Downloads for Optics
 


### PR DESCRIPTION
# Claire Deprecation

Claire has been deprecated by **Cloudflare Optics 🔭** (https://github.com/cloudflare/optics). Optics features Manifest V3 and Firefox support.

## Downloads for Optics

[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/mdjgbjnbdnhneejmmaabmccfehigbjbe.svg)](https://chrome.google.com/webstore/detail/optics/mdjgbjnbdnhneejmmaabmccfehigbjbe)
[![Firefox Add-ons](https://img.shields.io/amo/v/cloudflare-optics.svg)](https://addons.mozilla.org/firefox/addon/cloudflare-optics/)

#

See Optics team approvals on the previous PR #89 